### PR TITLE
Model tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llmpr",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "CLI tool for creating PR descriptions using OpenAI",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ const logger = {
 program
 	.version(VERSION)
 	.option('-b, --base <branch>', 'base branch to compare against', 'main')
-	.option('-m, --model <model>', 'OpenAI model to use', 'gpt-4o')
+	.option('-m, --model <model>', 'OpenAI model to use', 'gpt-4.1')
 	.option('-o, --output <file>', 'output file for PR description')
 	.option('-v, --verbose', 'show detailed logs and API responses')
 	.option('-s, --style <style>', 'PR description style (concise, standard, or verbose)', 'standard')


### PR DESCRIPTION
# PR: Bump Default OpenAI Model to `gpt-4.1` & Version Increment

## 1. Summary of Changes

- **Updated the default OpenAI model** used by the CLI tool from `gpt-4o` to `gpt-4.1`.
- **Incremented the package version** from `1.0.6` to `1.0.7` in `package.json`.

## 2. Purpose of This PR

The primary goal of this PR is to update the default AI model leveraged by the `llmpr` CLI. As OpenAI advances its model offerings, using the most recent and capable default (`gpt-4.1`) ensures improved output quality and takes advantage of the latest enhancements and bug fixes. The version bump reflects this non-breaking but notable improvement.

## 3. Key Implementation Details

- In `src/index.ts`, changed the commander option's default:
  ```diff
  - .option('-m, --model <model>', 'OpenAI model to use', 'gpt-4o')
  + .option('-m, --model <model>', 'OpenAI model to use', 'gpt-4.1')
  ```
  This means any new use of `llmpr` (without explicitly setting `--model`) will now utilize `gpt-4.1`.

- Updated `package.json` to reflect the new version:
  ```diff
  - "version": "1.0.6",
  + "version": "1.0.7",
  ```

## 4. Important Notes

- **Backward Compatibility:** There are no breaking changes. Users can still specify other models via the `--model` flag as before.
- **Awareness:** Some environments may require API access to the new `gpt-4.1` model; users should verify their API access is compatible.
- **Non-code Files:** No documentation or tests required updates since this is a default setting change.

---

**If additional detail is needed about model usage or CLI output, please advise.**