### PR TITLE
Refine suggested title generation with LLM compression

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ const logger = {
 program
 	.version(VERSION)
 	.option('-b, --base <branch>', 'base branch to compare against', 'main')
-	.option('-m, --model <model>', 'OpenAI model to use', 'gpt-5')
+	.option('-m, --model <model>', 'OpenAI model to use', 'gpt-5.1')
 	.option('-o, --output <file>', 'output file for PR description')
 	.option('-r, --review', 'generate a structured code review instead of a PR description')
 	.option('-v, --verbose', 'show detailed logs and API responses')

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,29 +179,39 @@ export function getGitDiff(): Promise<string> {
 	}).start()
 
 	return new Promise((resolve, reject) => {
-		exec(`git diff ${options.base}`, (err, stdout, stderr) => {
-			if (err) {
+		getMergeBase(options.base)
+			.then(mergeBase => {
+				exec(`git diff ${mergeBase}..HEAD`, (err, stdout, stderr) => {
+					if (err) {
+						spinner.fail()
+						reject(new Error(`Error getting git diff: ${stderr || err.message}`))
+						return
+					}
+					spinner.succeed(`Diff against ${colors.highlight(options.base)} successfully retrieved`)
+					resolve(stdout)
+				})
+			})
+			.catch(error => {
 				spinner.fail()
-				// Wrap in an Error object so error.message is set
-				reject(new Error(`Error getting git diff: ${stderr || err.message}`))
-				return
-			}
-			spinner.succeed(`Diff against ${colors.highlight(options.base)} successfully retrieved`)
-			resolve(stdout)
-		})
+				reject(error)
+			})
 	})
 }
 
 export function getChangedFiles(): Promise<string[]> {
 	return new Promise((resolve, reject) => {
-		exec(`git diff --name-only ${options.base}`, (err, stdout, stderr) => {
-			if (err) {
-				reject(new Error(`Error getting changed files: ${stderr || err.message}`))
-				return
-			}
-			// Return list of changed file paths
-			resolve(stdout.trim().split('\n').filter(line => line.trim() !== ''))
-		})
+		getMergeBase(options.base)
+			.then(mergeBase => {
+				exec(`git diff --name-only ${mergeBase}..HEAD`, (err, stdout, stderr) => {
+					if (err) {
+						reject(new Error(`Error getting changed files: ${stderr || err.message}`))
+						return
+					}
+					// Return list of changed file paths
+					resolve(stdout.trim().split('\n').filter(line => line.trim() !== ''))
+				})
+			})
+			.catch(error => reject(error))
 	})
 }
 
@@ -657,28 +667,44 @@ export function pushBranchToRemote(branch: string): Promise<void> {
  */
 export function getSuggestedTitle(): Promise<string> {
 	return new Promise((resolve, reject) => {
-		exec(`git log ${options.base}..HEAD --pretty=format:"%s" --no-merges`, (err, stdout, stderr) => {
-			if (err) {
-				reject(new Error(`Error getting commit messages: ${stderr || err.message}`))
-				return
-			}
+		getMergeBase(options.base)
+			.then(async mergeBase => {
+				try {
+					const commits = await getCommitSubjects(mergeBase)
+					const changedFiles = await getChangedFiles()
 
-			const commits = stdout.trim().split('\n').filter(line => line.trim() !== '')
+					if (commits.length === 0 && changedFiles.length === 0) {
+						resolve('Update changes')
+						return
+					}
 
-			if (commits.length === 0) {
-				resolve('Update changes')
-				return
-			}
+					const areaSummary = summarizeChangedAreas(changedFiles)
+					const commitSummary = summarizeCommitSubjects(commits)
 
-			// If only one commit, use its message
-			if (commits.length === 1) {
-				resolve(commits[0])
-				return
-			}
+					if (areaSummary && commitSummary) {
+						resolve(`${areaSummary}: ${commitSummary}`)
+						return
+					}
 
-			// If multiple commits, try to find a common theme or use the first one
-			resolve(commits[0])
-		})
+					if (areaSummary) {
+						resolve(areaSummary)
+						return
+					}
+
+					if (commitSummary) {
+						resolve(commitSummary)
+						return
+					}
+
+					resolve('Update changes')
+				} catch (error) {
+					const message = error instanceof Error ? error.message : String(error)
+					reject(new Error(`Error building suggested title: ${message}`))
+				}
+			})
+			.catch(error => {
+				reject(error instanceof Error ? error : new Error(String(error)))
+			})
 	})
 }
 
@@ -750,6 +776,91 @@ function requiresBranchPush(errorMessage: string): boolean {
 		normalized.includes('--head flag') ||
 		normalized.includes('set the remote') ||
 		normalized.includes('no upstream')
+}
+
+/**
+ * Get merge base between base branch and HEAD
+ */
+function getMergeBase(baseBranch: string): Promise<string> {
+	return new Promise((resolve, reject) => {
+		exec(`git merge-base ${baseBranch} HEAD`, (err, stdout, stderr) => {
+			if (err) {
+				reject(new Error(`Error finding merge-base with ${baseBranch}: ${stderr || err.message}`))
+				return
+			}
+			resolve(stdout.trim())
+		})
+	})
+}
+
+/**
+ * Get commit subjects from merge-base to HEAD (no merges)
+ */
+function getCommitSubjects(mergeBase: string): Promise<string[]> {
+	return new Promise((resolve, reject) => {
+		exec(`git log ${mergeBase}..HEAD --pretty=format:"%s" --no-merges`, (err, stdout, stderr) => {
+			if (err) {
+				reject(new Error(`Error getting commit messages: ${stderr || err.message}`))
+				return
+			}
+			const commits = stdout.trim().split('\n').filter(line => line.trim() !== '')
+			resolve(commits)
+		})
+	})
+}
+
+/**
+ * Build a short area-based summary from changed files
+ */
+function summarizeChangedAreas(changedFiles: string[]): string | undefined {
+	if (!changedFiles || changedFiles.length === 0) return undefined
+
+	const areaCounts: Record<string, number> = {}
+
+	changedFiles.forEach(file => {
+		const area = file.includes('/') ? file.split('/')[0] : 'root files'
+		areaCounts[area] = (areaCounts[area] || 0) + 1
+	})
+
+	const sortedAreas = Object.entries(areaCounts)
+		.sort((a, b) => b[1] - a[1])
+		.map(([area]) => area)
+
+	if (sortedAreas.length === 1) {
+		return `Update ${titleCase(sortedAreas[0])}`
+	}
+
+	const primary = titleCase(sortedAreas[0])
+	const secondary = titleCase(sortedAreas[1])
+	return `${primary} & ${secondary} updates`
+}
+
+/**
+ * Build a concise summary from commit subjects
+ */
+function summarizeCommitSubjects(commits: string[]): string | undefined {
+	if (!commits || commits.length === 0) return undefined
+
+	// Normalize conventional commit prefixes to focus on the message
+	const cleaned = commits.map(c => {
+		const match = c.match(/^[a-z]+(?:\([^)]+\))?:\s*(.*)$/i)
+		return match ? match[1].trim() : c.trim()
+	})
+
+	if (cleaned.length === 1) {
+		return cleaned[0]
+	}
+
+	// Take top two unique phrases to avoid overly long titles
+	const unique = Array.from(new Set(cleaned)).slice(0, 2)
+	return unique.join(' • ')
+}
+
+function titleCase(text: string): string {
+	return text
+		.split(/[-_\s]+/)
+		.map(word => word.charAt(0).toUpperCase() + word.slice(1))
+		.join(' ')
 }
 
 /**


### PR DESCRIPTION
# PR: Accurate diffs via merge-base and smarter title suggestions; default model -> gpt-5.1

## Summary of changes
- Compare changes against the merge-base with the base branch instead of the branch tip.
- Improve PR title suggestion with commit + file-area summarization and optional LLM compression.
- Update default OpenAI model from `gpt-5` to `gpt-5.1`.
- Hardened error handling and clearer spinner feedback.

## Purpose of the PR
- Ensure diffs and changed files reflect only what diverged from the base branch (avoiding noise when the feature branch is behind or has merges).
- Generate concise, meaningful PR titles that reflect both commits and changed areas.
- Use the latest default LLM model by default.

## Key implementation details
- Use merge-base for diffs and file lists:
  - Introduced `getMergeBase(base)` and switched commands to `mergeBase..HEAD`:
    ```ts
    // before
    git diff ${options.base}
    git diff --name-only ${options.base}

    // after
    git diff ${mergeBase}..HEAD
    git diff --name-only ${mergeBase}..HEAD
    ```
- Smarter title generation:
  - New helpers:
    - `getCommitSubjects(mergeBase)`: commit subjects from merge-base to HEAD (no merges).
    - `summarizeChangedAreas(files)`: primary/secondary area summary from paths.
    - `summarizeCommitSubjects(commits)`: normalize conventional commits; take top 1–2 messages.
    - `buildBaseTitle(areaSummary, commitSummary)`: combine area + commit summaries.
    - `compressTitleWithLLM(baseTitle, changedFiles)`: optional short compression via LLM; falls back on failures.
  - `getSuggestedTitle()` now:
    - Uses merge-base.
    - Considers both commit subjects and changed files.
    - Falls back to “Update changes” when no signals are available.

- CLI default model:
  ```ts
  .option('-m, --model <model>', 'OpenAI model to use', 'gpt-5.1')
  ```

- Error handling and UX:
  - Clear spinner success/failure around diff retrieval.
  - Consistent error wrapping so `error.message` is meaningful.

## Important notes or warnings
- Behavior change: Diffs and changed files are now computed from `merge-base(base, HEAD)` rather than directly against the base branch tip. This typically provides more accurate results on long-lived branches or when not rebased.
- Ensure the base branch exists locally in CI. If using shallow clones, fetch the base branch (e.g., `fetch-depth: 0`) so `git merge-base` can resolve correctly.
- Title compression uses the OpenAI API:
  - Requires a valid API key (`getApiKey()`); if missing or the call fails, we fall back to the non-LLM base title.
  - You can still override the model via `--model`; default is now `gpt-5.1`.