### PR TITLE
Add interactive LLM provider configuration setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ llmpr [options]
 | `-t, --template <file>` | Custom prompt template file (see [Custom templates](#custom-templates)) |
 | `--dry-run` | Show the prompt that would be sent without calling the LLM |
 | `-gh, --github-config` | Check GitHub CLI auth and repo access, then exit |
+| `config` | Interactive setup for provider and model (see [Configuration](#configuration)) |
 | `-h, --help` | Display help |
 | `-V, --version` | Display version |
 
@@ -134,6 +135,9 @@ llmpr --dry-run
 # Custom prompt template
 llmpr --template ./my-pr-prompt.md
 
+# Interactive config setup (provider + model)
+llmpr config
+
 # Check GitHub CLI and repo access
 llmpr --github-config
 
@@ -153,6 +157,20 @@ Defaults can be set via config files. CLI options override config.
 
 - **Project**: `.llmprrc.json` in the repo root  
 - **User**: `~/.config/llmpr/config.json`
+
+### Interactive setup: `llmpr config`
+
+Run the config wizard to create or update a config file with prompts for provider and model:
+
+```bash
+llmpr config
+```
+
+You’ll be asked:
+
+1. **Default provider?** — OpenAI, Anthropic (Claude), or OpenAI-compatible
+2. **Default model?** — List depends on provider (e.g. gpt-5.2, gpt-5.1, gpt-5-mini for OpenAI; claude-sonnet-4-20250514, etc. for Anthropic)
+3. **Save config to** — This project (`.llmprrc.json`) or user config (`~/.config/llmpr/config.json`)
 
 Example `.llmprrc.json`:
 

--- a/README.md
+++ b/README.md
@@ -2,18 +2,22 @@
 
 > AI-powered Pull Request descriptions with one command
 
-LLMPR generates professional PR descriptions—and now structured code reviews—from your Git changes using OpenAI's language models.
+LLMPR generates professional PR descriptions—and structured code reviews—from your Git changes using your choice of LLM: OpenAI, Anthropic (Claude), or any OpenAI-compatible API (e.g. Ollama, Together).
 
 ## Features
 
-- 🔄 **Git Integration**: Analyzes your current branch changes
-- 🎨 **Two Styles**: Choose concise or verbose descriptions
+- 🔄 **Git Integration**: Analyzes your current branch changes (large diffs are truncated automatically)
+- 🤖 **Multiple Providers**: Use OpenAI, Anthropic, or any OpenAI-compatible endpoint
+- ⚙️ **Config Files**: Set defaults in `.llmprrc.json` or `~/.config/llmpr/config.json`
+- 🎨 **Three Styles**: Choose concise, standard, or verbose descriptions
 - 📊 **Smart Visualizations**: Generates diagrams and code comparisons when needed
 - 🔍 **Context-Aware**: Can request specific file contents for better understanding
 - 📁 **Directory Visualization**: Shows repository structure with focus on changed files
 - 📏 **Customizable Length**: Control the maximum size of your PR descriptions
+- 📝 **Custom Templates**: Use `--template` with placeholders for your own prompt
 - 🚀 **Interactive PR Creation**: Create GitHub PRs directly from the CLI with interactive prompts
 - 🧠 **AI Review Mode**: Request a structured Good/Bad/Suggestions/Critical review of your diff
+- 🔎 **Dry Run**: Preview the prompt without calling the LLM (`--dry-run`)
 
 ## Installation
 
@@ -35,15 +39,21 @@ npm install -g .
 
 ## Prerequisites
 
-You need to have an OpenAI API key. You can get one from [OpenAI's website](https://platform.openai.com/).
+You need an API key for at least one supported provider. By default LLMPR uses OpenAI.
 
-Set your API key as an environment variable:
+| Provider | Env variable(s) | Notes |
+|----------|------------------|--------|
+| **OpenAI** (default) | `OPENAI_API_KEY` | [Get a key](https://platform.openai.com/) |
+| **Anthropic** (Claude) | `ANTHROPIC_API_KEY` | [Get a key](https://console.anthropic.com/) |
+| **OpenAI-compatible** | `LLM_API_KEY`, optionally `LLM_BASE_URL` | For Ollama, Together, local endpoints, etc. |
+
+Example (OpenAI):
 
 ```bash
 export OPENAI_API_KEY=your_api_key
 ```
 
-Or add it to your shell profile for persistence (e.g., ~/.bash_profile, ~/.zshrc):
+Or add it to your shell profile for persistence (e.g. `~/.zshrc`):
 
 ```bash
 echo 'export OPENAI_API_KEY=your_api_key' >> ~/.zshrc
@@ -52,7 +62,7 @@ source ~/.zshrc
 
 ## Quick Start
 
-1. Set your OpenAI API key:
+1. Set an API key for your chosen provider (e.g. OpenAI):
    ```bash
    export OPENAI_API_KEY=your_api_key
    ```
@@ -73,13 +83,17 @@ llmpr [options]
 | Option | Description |
 |--------|-------------|
 | `-b, --base <branch>` | Base branch to compare against (default: "main") |
-| `-m, --model <model>` | OpenAI model to use (default: "gpt-5") |
+| `-m, --model <model>` | LLM model to use (default: "gpt-5.1") |
 | `-o, --output <file>` | Save PR description to file |
 | `-r, --review` | Generate a structured code review instead of a PR description |
 | `-v, --verbose` | Show detailed logs and API responses |
 | `-s, --style <style>` | PR style: "concise", "standard", or "verbose" (default: "standard") |
 | `-l, --max-length <words>` | Maximum length in words (default: 500) |
 | `-c, --create-pr` | Create a GitHub PR after generating description (interactive) |
+| `-p, --provider <provider>` | LLM provider: "openai", "anthropic", or "openai-compatible" (default: "openai") |
+| `-t, --template <file>` | Custom prompt template file (see [Custom templates](#custom-templates)) |
+| `--dry-run` | Show the prompt that would be sent without calling the LLM |
+| `-gh, --github-config` | Check GitHub CLI auth and repo access, then exit |
 | `-h, --help` | Display help |
 | `-V, --version` | Display version |
 
@@ -104,8 +118,24 @@ llmpr -r -o review.md
 # Limit length to 300 words
 llmpr --max-length 300
 
-# Use specific OpenAI model
+# Use specific model
 llmpr --model gpt-4-turbo
+
+# Use Anthropic (Claude)
+llmpr --provider anthropic --model claude-sonnet-4-20250514
+
+# Use OpenAI-compatible endpoint (e.g. Ollama)
+export LLM_BASE_URL=http://localhost:11434/v1
+llmpr --provider openai-compatible --model llama3.2
+
+# Preview prompt without calling the LLM
+llmpr --dry-run
+
+# Custom prompt template
+llmpr --template ./my-pr-prompt.md
+
+# Check GitHub CLI and repo access
+llmpr --github-config
 
 # Generate description and create PR interactively
 llmpr --create-pr
@@ -116,6 +146,41 @@ llmpr --base develop --create-pr
 # Combine options for complete workflow
 llmpr --base develop --style verbose --create-pr
 ```
+
+## Configuration
+
+Defaults can be set via config files. CLI options override config.
+
+- **Project**: `.llmprrc.json` in the repo root  
+- **User**: `~/.config/llmpr/config.json`
+
+Example `.llmprrc.json`:
+
+```json
+{
+  "base": "main",
+  "model": "gpt-4o",
+  "style": "standard",
+  "maxLength": "500",
+  "provider": "openai"
+}
+```
+
+Supported keys: `base`, `model`, `style`, `maxLength`, `provider`, `verbose`.
+
+## Custom templates
+
+Use `-t, --template <file>` to supply your own prompt. The file can use these placeholders:
+
+| Placeholder | Replaced with |
+|-------------|----------------|
+| `{{diff}}` | Git diff against base branch |
+| `{{dirStructure}}` | Repository tree (focused on changed files) |
+| `{{style}}` | Current style (concise / standard / verbose) |
+| `{{maxLength}}` | Max length in words |
+| `{{base}}` | Base branch name |
+
+The LLM will receive the result as the system/user prompt. Use this for team-specific formats or extra instructions.
 
 ## Interactive PR Creation
 
@@ -195,7 +260,7 @@ LLMPR can automatically generate PR descriptions when PRs are created or on dema
 
 ### Setup
 
-1. Add your OpenAI API key to GitHub Secrets as `OPENAI_API_KEY`
+1. Add your LLM API key to GitHub Secrets (e.g. `OPENAI_API_KEY` for the default provider, or `ANTHROPIC_API_KEY` if using `--provider anthropic`).
 2. Create a workflow file at `.github/workflows/pr-description.yml`:
 
 ```yaml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llmpr",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "CLI tool for generating AI-powered PR descriptions and code reviews",
   "main": "dist/index.js",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,8 @@ export const CLI_DEFAULTS: Record<string, unknown> = {
  */
 export function parseArgs(argv: string[] = process.argv): CliOptions {
 	const program = new Command()
-	program.version(VERSION)
+	program
+		.version(VERSION)
 		.option('-b, --base <branch>', 'base branch to compare against', 'main')
 		.option('-m, --model <model>', 'LLM model to use', 'gpt-5.1')
 		.option('-o, --output <file>', 'output file for PR description')
@@ -52,6 +53,9 @@ Provider options:
   - openai: OpenAI API (requires OPENAI_API_KEY)
   - anthropic: Anthropic Claude API (requires ANTHROPIC_API_KEY)
   - openai-compatible: Any OpenAI-compatible endpoint (uses LLM_API_KEY, LLM_BASE_URL)
+
+Commands:
+  config    Set up provider and model defaults interactively
 `)
 		.parse(argv)
 

--- a/src/config-setup.ts
+++ b/src/config-setup.ts
@@ -1,0 +1,106 @@
+/**
+ * Interactive config setup: llmpr config
+ */
+
+import { writeFileSync, mkdirSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
+import prompts from 'prompts'
+import { colors, logger } from './ui.js'
+import type { AppConfig } from './types.js'
+
+const PROVIDER_MODELS: Record<string, string[]> = {
+	openai: [
+		'gpt-5.2',
+		'gpt-5.1',
+		'gpt-5-mini',
+		'gpt-4o',
+		'gpt-4o-mini',
+		'gpt-4-turbo',
+		'gpt-4',
+	],
+	anthropic: [
+		'claude-sonnet-4-20250514',
+		'claude-3-5-sonnet-20241022',
+		'claude-3-5-haiku-20241022',
+		'claude-3-opus-20240229',
+		'claude-3-sonnet-20240229',
+	],
+	'openai-compatible': [
+		'llama3.2',
+		'llama3.1',
+		'codellama',
+		'mistral',
+		'qwen2.5',
+	],
+}
+
+export async function runConfigSetup(): Promise<void> {
+	logger.title('LLMPR Config')
+	logger.info('Set your default provider and model. You can override these with flags when running llmpr.')
+
+	const providerRes = await prompts({
+		type: 'select',
+		name: 'provider',
+		message: 'Default provider?',
+		choices: [
+			{ title: 'OpenAI', value: 'openai' },
+			{ title: 'Anthropic (Claude)', value: 'anthropic' },
+			{ title: 'OpenAI-compatible (Ollama, etc.)', value: 'openai-compatible' },
+		],
+		initial: 0,
+	})
+
+	if (providerRes.provider === undefined) {
+		logger.warning('Config cancelled')
+		return
+	}
+
+	const models = PROVIDER_MODELS[providerRes.provider] ?? []
+	const modelRes = await prompts({
+		type: 'select',
+		name: 'model',
+		message: 'Default model?',
+		choices: models.map(m => ({ title: m, value: m })),
+		initial: 0,
+	})
+
+	if (modelRes.model === undefined) {
+		logger.warning('Config cancelled')
+		return
+	}
+
+	const config: AppConfig = {
+		provider: providerRes.provider,
+		model: modelRes.model,
+	}
+
+	const whereRes = await prompts({
+		type: 'select',
+		name: 'where',
+		message: 'Save config to',
+		choices: [
+			{ title: 'This project (.llmprrc.json)', value: 'project' },
+			{ title: 'User config (~/.config/llmpr/config.json)', value: 'user' },
+		],
+		initial: 0,
+	})
+
+	if (whereRes.where === undefined) {
+		logger.warning('Config cancelled')
+		return
+	}
+
+	let filepath: string
+	if (whereRes.where === 'project') {
+		filepath = join(process.cwd(), '.llmprrc.json')
+	} else {
+		const dir = join(homedir(), '.config', 'llmpr')
+		mkdirSync(dir, { recursive: true })
+		filepath = join(dir, 'config.json')
+	}
+
+	writeFileSync(filepath, JSON.stringify(config, null, 2) + '\n', 'utf8')
+	logger.success(`Config written to ${colors.highlight(filepath)}`)
+	logger.info(`Provider: ${colors.highlight(providerRes.provider)}, Model: ${colors.highlight(modelRes.model)}`)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-import { writeFileSync, readFileSync } from 'fs'
+import { writeFileSync, readFileSync, realpathSync } from 'fs'
+import { pathToFileURL, fileURLToPath } from 'url'
 import { parseArgs, CLI_DEFAULTS } from './cli.js'
 import { loadConfig, mergeConfigWithDefaults } from './config.js'
 import { getGitDiff, getChangedFiles, getDirectoryStructure, truncateDiff } from './git.js'
@@ -197,10 +198,21 @@ export async function main(argv?: string[]) {
 	}
 }
 
-// ESM-compatible main module check
-const isMainModule = process.argv[1] && import.meta.url === `file://${process.argv[1]}`
+// ESM-compatible main module check (handles symlinks and path normalization)
+function isMainModule(): boolean {
+	const scriptPath = process.argv[1]
+	if (!scriptPath) return false
+	try {
+		const modulePath = fileURLToPath(import.meta.url)
+		const moduleReal = realpathSync(modulePath)
+		const scriptReal = realpathSync(scriptPath)
+		return moduleReal === scriptReal
+	} catch {
+		return pathToFileURL(scriptPath).href === import.meta.url
+	}
+}
 
-if (isMainModule) {
+if (isMainModule()) {
 	logger.info('Starting LLMPR...')
 	main().catch(error => {
 		logger.error(`An error occurred: ${error.message}`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,14 @@ async function handleGithubConfig(options: CliOptions): Promise<void> {
 }
 
 export async function main(argv?: string[]) {
+	const args = argv ?? process.argv.slice()
+	const firstArg = args[2]
+	if (firstArg === 'config') {
+		const { runConfigSetup } = await import('./config-setup.js')
+		await runConfigSetup()
+		return
+	}
+
 	const cliOptions = parseArgs(argv)
 	const config = loadConfig()
 	const options = mergeConfigWithDefaults(cliOptions, config, CLI_DEFAULTS)

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -7,7 +7,10 @@ import type { CliOptions } from './types.js'
 export function buildPrDescriptionPrompt(diff: string, dirStructure: string, options: CliOptions): string {
 	return `
 You are an assistant that helps write PR descriptions.
-The diff from my branch compared to ${options.base} is:
+
+**Diff interpretation (important):** The diff below shows ONLY the changes on the current branch since it diverged from ${options.base} (merge-base to HEAD). It does NOT include changes that were added to ${options.base} after the branch was created. In the diff: lines prefixed with \`-\` were REMOVED on this branch; lines prefixed with \`+\` were ADDED on this branch. Do not describe content that exists only on ${options.base} (e.g. additions that landed on ${options.base} after branching) as if it were removed or deleted on this branch. Describe only what this branch actually changed.
+
+The diff is:
 ${diff}
 
 The repository structure is:
@@ -85,7 +88,9 @@ export function buildReviewPrompt(diff: string, dirStructure: string, options: C
 	return `
 You are a senior software engineer performing a rigorous peer review.
 
-The diff from my branch compared to ${options.base} is:
+**Diff interpretation (important):** The diff below shows ONLY the changes on the current branch since it diverged from ${options.base} (merge-base to HEAD). It does NOT include changes that were added to ${options.base} after the branch was created. In the diff: lines prefixed with \`-\` were REMOVED on this branch; lines prefixed with \`+\` were ADDED on this branch. Do not treat content that exists only on ${options.base} (e.g. additions that landed on ${options.base} after branching) as if it were removed or deleted on this branch. Review only what this branch actually changed.
+
+The diff is:
 ${diff}
 
 The repository structure is:


### PR DESCRIPTION
## 1. Summary of Changes

- Expanded LLM provider support and documentation:
  - README now documents OpenAI, Anthropic (Claude), and generic OpenAI-compatible endpoints, environment variables, and usage examples.
  - Added documentation for config files, interactive `llmpr config`, custom templates, `--dry-run`, and `--github-config`.
- New interactive config command:
  - Added `llmpr config` subcommand to set default provider/model and write either project-level or user-level config.
- CLI and runtime improvements:
  - CLI help text updated with provider info and new commands/options.
  - Model default updated to `gpt-5.1`.
  - More robust ESM “main module” detection to correctly handle symlinks and path normalization.
- Prompt quality improvements:
  - PR description and review prompts now explicitly explain how to interpret diffs (merge-base semantics, +/- line meaning).
- Version bump from `2.0.0` to `2.0.1`.

---

## 2. Purpose of the PR

- Make LLMPR easier to configure for different providers and environments (OpenAI, Anthropic, Ollama, etc.).
- Provide a guided setup flow so users can quickly establish sensible defaults without manually editing JSON.
- Prevent misinterpretation of diffs by LLMs, improving accuracy of generated PR descriptions and reviews.
- Fix issues when running the CLI via symlinked or globally-installed binaries in ESM mode.

---

## 3. Key Implementation Details

### Interactive Config Setup (`llmpr config`)

New module: `src/config-setup.ts`:

```ts
export async function runConfigSetup(): Promise<void> {
  // 1. Prompt for provider (openai / anthropic / openai-compatible)
  // 2. Prompt for model from a curated list per provider
  // 3. Prompt where to save: project `.llmprrc.json` or user `~/.config/llmpr/config.json`
  // 4. Write minimal JSON config { provider, model } and log success
}
```

- Uses `prompts` for interactive selection.
- Model options are pre-populated per provider (`PROVIDER_MODELS`), including recent GPT and Claude variants and common OpenAI-compatible model names.
- Writes config with `mkdirSync` (recursive) for user-level path and `writeFileSync` for the file.

### Wiring the `config` Command

- `src/index.ts` now inspects the raw argv before normal CLI parsing:

```ts
const args = argv ?? process.argv.slice()
const firstArg = args[2]
if (firstArg === 'config') {
  const { runConfigSetup } = await import('./config-setup.js')
  await runConfigSetup()
  return
}
```

- `src/cli.ts` help text documents `config` under “Commands”.
- README documents `llmpr config` and shows example `.llmprrc.json`, including supported keys.

### ESM Main Module Detection

Replaced a naïve `import.meta.url === file://${process.argv[1]}` check with a more robust function:

```ts
function isMainModule(): boolean {
  const scriptPath = process.argv[1]
  if (!scriptPath) return false
  try {
    const modulePath = fileURLToPath(import.meta.url)
    const moduleReal = realpathSync(modulePath)
    const scriptReal = realpathSync(scriptPath)
    return moduleReal === scriptReal
  } catch {
    return pathToFileURL(scriptPath).href === import.meta.url
  }
}
```

This ensures the CLI starts correctly even when invoked via symlinks.

### Prompt Enhancements

Both `buildPrDescriptionPrompt` and `buildReviewPrompt` prepend a detailed explanation of how to interpret the diff:

- Clarifies that the diff is from merge-base to HEAD.
- States that `-` lines are removed on this branch, `+` lines are added on this branch.
- Instructs the model not to treat content that exists only on the base branch as removed.

This aims to reduce hallucinated “deletions” from unrelated main-branch changes.

---

## 4. Important Notes / Warnings

- Existing configs remain valid; the new interactive setup only writes `provider` and `model` unless extended later.
- Users relying on older default models should be aware the CLI now defaults to `gpt-5.1` (config/CLI flags override this).
- For OpenAI-compatible providers, users must correctly set `LLM_API_KEY` and, when needed, `LLM_BASE_URL` as documented in the README.